### PR TITLE
feat: prepare RecombeeClient for Swift 6.0 concurency

### DIFF
--- a/Sources/RecombeeClient/ApiClient/RecombeeClient.swift
+++ b/Sources/RecombeeClient/ApiClient/RecombeeClient.swift
@@ -5,7 +5,7 @@ import Foundation
 /// A client for communicating with the Recombee API.
 ///
 /// Use this class to send interaction events and fetch recommendations and search results.
-public class RecombeeClient {
+public class RecombeeClient: @unchecked Sendable {
     private let baseUrl: String
     private let databaseId: String
     private let publicToken: String
@@ -72,9 +72,8 @@ public class RecombeeClient {
     /// - Parameter request: The typed request to send.
     public func sendDetached<T: Request>(_ request: T) {
         Task.detached(priority: .utility) { [weak self] in
-            guard let self = self else { return }
             do {
-                _ = try await self.send(request)
+                _ = try await self?.send(request)
             } catch {
                 print("Error sending request: \(error.localizedDescription)")
             }

--- a/Sources/RecombeeClient/Bindings/BatchResponse.swift
+++ b/Sources/RecombeeClient/Bindings/BatchResponse.swift
@@ -1,22 +1,27 @@
-import AnyCodable
+@preconcurrency import AnyCodable
 import Foundation
 
 /// A type-erased wrapper for `RecombeeBinding` objects.
 public struct AnyRecombeeBinding: RecombeeBinding {
     public typealias CodingKeys = NoCodingKeys
 
-    private let value: Any
+    private enum Value: Sendable {
+        case dictionary([String: AnyCodable])
+        case string(String)
+    }
+
+    private let value: Value
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         // Try decoding as a dictionary
         if let dictionary = try? container.decode([String: AnyCodable].self) {
-            value = dictionary
+            value = .dictionary(dictionary)
         }
         // Try decoding as a string
         else if let string = try? container.decode(String.self) {
-            value = string
+            value = .string(string)
         }
         // Handle unsupported types
         else {
@@ -32,16 +37,18 @@ public struct AnyRecombeeBinding: RecombeeBinding {
 
     public func decode<T: RecombeeBinding>(as _: T.Type) throws -> T {
         // Handle JSON objects
-        if let dictionary = value as? [String: AnyCodable] {
+        switch value {
+        case .dictionary(let dictionary):
             // Map to JSON-compatible `[String: Any]`
             let jsonCompatible = dictionary.mapValues { $0.value }
             let jsonData = try JSONSerialization.data(withJSONObject: jsonCompatible)
             return try JSONDecoder().decode(T.self, from: jsonData)
-        }
 
-        // Handle single string values for `StringResponseBinding`
-        if let stringValue = value as? String, T.self == StringResponseBinding.self {
-            return StringResponseBinding(response: stringValue) as! T
+        case.string(let string):
+            // Handle single string values for `StringResponseBinding`
+            if T.self == StringResponseBinding.self {
+                return StringResponseBinding(response: string) as! T
+            }
         }
 
         // Unsupported value
@@ -60,7 +67,7 @@ public struct AnyRecombeeBinding: RecombeeBinding {
 public enum NoCodingKeys: Swift.CodingKey {}
 
 /// Represents the response for a single request within a batch.
-public struct BatchResponse<ResponseType: RecombeeBinding>: Decodable {
+public struct BatchResponse<ResponseType: RecombeeBinding>: Decodable, Sendable {
     /// The HTTP status code returned for this individual request
     public let statusCode: Int
 

--- a/Sources/RecombeeClient/Bindings/BatchResponse.swift
+++ b/Sources/RecombeeClient/Bindings/BatchResponse.swift
@@ -38,13 +38,13 @@ public struct AnyRecombeeBinding: RecombeeBinding {
     public func decode<T: RecombeeBinding>(as _: T.Type) throws -> T {
         // Handle JSON objects
         switch value {
-        case .dictionary(let dictionary):
+        case let .dictionary(dictionary):
             // Map to JSON-compatible `[String: Any]`
             let jsonCompatible = dictionary.mapValues { $0.value }
             let jsonData = try JSONSerialization.data(withJSONObject: jsonCompatible)
             return try JSONDecoder().decode(T.self, from: jsonData)
 
-        case.string(let string):
+        case let .string(string):
             // Handle single string values for `StringResponseBinding`
             if T.self == StringResponseBinding.self {
                 return StringResponseBinding(response: string) as! T

--- a/Sources/RecombeeClient/Bindings/Logic.swift
+++ b/Sources/RecombeeClient/Bindings/Logic.swift
@@ -3,7 +3,7 @@
  */
 
 /// Logic Binding
-public struct Logic: RecombeeBinding, Encodable, Sendable {
+public struct Logic: RecombeeBinding, Encodable {
     public typealias CodingKeys = LogicCodingKeys
 
     /// Name of the logic that should be used

--- a/Sources/RecombeeClient/Bindings/Logic.swift
+++ b/Sources/RecombeeClient/Bindings/Logic.swift
@@ -3,7 +3,7 @@
  */
 
 /// Logic Binding
-public struct Logic: RecombeeBinding, Encodable {
+public struct Logic: RecombeeBinding, Encodable, Sendable {
     public typealias CodingKeys = LogicCodingKeys
 
     /// Name of the logic that should be used

--- a/Sources/RecombeeClient/Bindings/RecombeeBinding.swift
+++ b/Sources/RecombeeClient/Bindings/RecombeeBinding.swift
@@ -1,7 +1,7 @@
 import AnyCodable
 
 /// A protocol for response types that can be decoded from the Recombee API.
-public protocol RecombeeBinding: Decodable {
+public protocol RecombeeBinding: Decodable, Sendable {
     associatedtype CodingKeys: Swift.CodingKey
 }
 

--- a/Sources/RecombeeClient/Requests/Request.swift
+++ b/Sources/RecombeeClient/Requests/Request.swift
@@ -4,7 +4,7 @@ import Foundation
 ///
 /// Conforming types define the endpoint path, HTTP method, parameters, and expected response type.
 /// This protocol is used internally by the SDK to standardize request construction and dispatching.
-public protocol Request {
+public protocol Request: Sendable {
     /// The expected response type returned by the API.
     associatedtype Response: RecombeeBinding
 

--- a/Sources/RecombeeClient/Utils/JsonDictionary.swift
+++ b/Sources/RecombeeClient/Utils/JsonDictionary.swift
@@ -1,7 +1,7 @@
-import AnyCodable
+@preconcurrency import AnyCodable
 
 /// A flexible, JSON-compatible dictionary used throughout the SDK.
-public struct JSONDictionary: Codable {
+public struct JSONDictionary: Codable, Sendable {
     private var internalStorage: [String: AnyCodable]
 
     public init(_ dictionary: [String: Any] = [:]) {


### PR DESCRIPTION
Mark necessary protocols and types as `Sendable`. Use `@unchecked Sendable` for RecombeeClient. Rework AnyBinding to not use Any as Any cant be sendable by design, instead use more type safe way.

RecombeeClient `class` as a whole could be replaced with `actor` but then the idea of fire and forget `sendDetached` would miss a point as we would still need to await the function call in the client apps. This way I've only marked the class as `@unchecked Sendable` as the class itself does not have any mutating properties and there is no data race issues.